### PR TITLE
PEG-2848: Restore azure-pipelines ref to main

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -21,7 +21,7 @@ resources:
       type: github
       name: hmcts/cpp-azure-devops-templates
       endpoint: 'hmcts'
-      ref: dev/enforcer-disabled
+      ref: 'main'
 
 pool:
   name: "MDV-ADO-AGENT-AKS-01"


### PR DESCRIPTION
Switch cppAzureDevOpsTemplates ref from dev/enforcer-disabled back to main.