### PR TITLE
PEG-2848: Bump pom to -PEG-2848-R-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.gov.moj.cpp.staging.dcs</groupId>
     <artifactId>stagingdcs-parent</artifactId>
-    <version>17.103.13-RBSD-2609-SNAPSHOT</version>
+    <version>17.103.13-PEG-2848-R-SNAPSHOT</version>
     <properties>
         <mvn.site.url>file://${project.build.directory}/site</mvn.site.url>
         <commons-dbutils.version>1.6</commons-dbutils.version>

--- a/stagingdcs-command-api/pom.xml
+++ b/stagingdcs-command-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingdcs-parent</artifactId>
         <groupId>uk.gov.moj.cpp.staging.dcs</groupId>
-        <version>17.103.13-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.13-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingdcs-domain-common/pom.xml
+++ b/stagingdcs-domain-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.staging.dcs</groupId>
         <artifactId>stagingdcs-parent</artifactId>
-        <version>17.103.13-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.13-PEG-2848-R-SNAPSHOT</version>
     </parent>
 
     <artifactId>stagingdcs-domain-common</artifactId>

--- a/stagingdcs-event-processor/pom.xml
+++ b/stagingdcs-event-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.staging.dcs</groupId>
         <artifactId>stagingdcs-parent</artifactId>
-        <version>17.103.13-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.13-PEG-2848-R-SNAPSHOT</version>
     </parent>
 
     <artifactId>stagingdcs-event-processor</artifactId>

--- a/stagingdcs-event-sources/pom.xml
+++ b/stagingdcs-event-sources/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.staging.dcs</groupId>
         <artifactId>stagingdcs-parent</artifactId>
-        <version>17.103.13-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.13-PEG-2848-R-SNAPSHOT</version>
     </parent>
 
     <artifactId>stagingdcs-event-sources</artifactId>

--- a/stagingdcs-healthchecks/pom.xml
+++ b/stagingdcs-healthchecks/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.staging.dcs</groupId>
         <artifactId>stagingdcs-parent</artifactId>
-        <version>17.103.13-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.13-PEG-2848-R-SNAPSHOT</version>
     </parent>
 
     <artifactId>stagingdcs-healthchecks</artifactId>

--- a/stagingdcs-integration-test/pom.xml
+++ b/stagingdcs-integration-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.staging.dcs</groupId>
         <artifactId>stagingdcs-parent</artifactId>
-        <version>17.103.13-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.13-PEG-2848-R-SNAPSHOT</version>
     </parent>
 
     <artifactId>stagingdcs-integration-test</artifactId>

--- a/stagingdcs-persistence/pom.xml
+++ b/stagingdcs-persistence/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.staging.dcs</groupId>
         <artifactId>stagingdcs-parent</artifactId>
-        <version>17.103.13-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.13-PEG-2848-R-SNAPSHOT</version>
     </parent>
 
     <artifactId>stagingdcs-persistence</artifactId>

--- a/stagingdcs-persistence/stagingdcs-liquibase/pom.xml
+++ b/stagingdcs-persistence/stagingdcs-liquibase/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.staging.dcs</groupId>
         <artifactId>stagingdcs-persistence</artifactId>
-        <version>17.103.13-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.13-PEG-2848-R-SNAPSHOT</version>
     </parent>
 
     <artifactId>stagingdcs-liquibase</artifactId>

--- a/stagingdcs-persistence/stagingdcs-persistence-api/pom.xml
+++ b/stagingdcs-persistence/stagingdcs-persistence-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.staging.dcs</groupId>
         <artifactId>stagingdcs-persistence</artifactId>
-        <version>17.103.13-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.13-PEG-2848-R-SNAPSHOT</version>
     </parent>
 
     <artifactId>stagingdcs-persistence-api</artifactId>

--- a/stagingdcs-query-api/pom.xml
+++ b/stagingdcs-query-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.staging.dcs</groupId>
         <artifactId>stagingdcs-parent</artifactId>
-        <version>17.103.13-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.13-PEG-2848-R-SNAPSHOT</version>
     </parent>
 
     <artifactId>stagingdcs-query-api</artifactId>

--- a/stagingdcs-service/pom.xml
+++ b/stagingdcs-service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.staging.dcs</groupId>
         <artifactId>stagingdcs-parent</artifactId>
-        <version>17.103.13-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.13-PEG-2848-R-SNAPSHOT</version>
     </parent>
 
     <artifactId>stagingdcs-service</artifactId>


### PR DESCRIPTION
Bumps pom versions to -PEG-2848-R-SNAPSHOT for R-candidate build.