### PR TITLE
PEG-2848: Sync pom properties with team/release-engg-2609

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,11 @@
         <mvn.site.url>file://${project.build.directory}/site</mvn.site.url>
         <commons-dbutils.version>1.6</commons-dbutils.version>
         <jgitflow.maven.developBranchName>main</jgitflow.maven.developBranchName>
-        <coredomain.version>17.103.10</coredomain.version>
-        <progression.version>17.0.248</progression.version>
-        <referencedata.version>17.103.131</referencedata.version>
+        <coredomain.version>17.103.12</coredomain.version>
+        <progression.version>17.0.240</progression.version>
+        <referencedata.version>17.103.129</referencedata.version>
         <defence.version>17.0.86</defence.version>
-        <usersgroups.version>17.104.47</usersgroups.version>
+        <usersgroups.version>17.104.46</usersgroups.version>
         <material.version>17.0.70</material.version>
         <api-dcs-crime-version>0.9.3</api-dcs-crime-version>
         <api-cp-crime.version>0.3.2</api-cp-crime.version>


### PR DESCRIPTION
## Summary
Syncs this repo's `pom.xml` `<properties>` version entries with `team/release-engg-2609`.

## Changes
```
-        <coredomain.version>17.103.10</coredomain.version>
-        <progression.version>17.0.248</progression.version>
-        <referencedata.version>17.103.131</referencedata.version>
+        <coredomain.version>17.103.12</coredomain.version>
+        <progression.version>17.0.240</progression.version>
+        <referencedata.version>17.103.129</referencedata.version>
-        <usersgroups.version>17.104.47</usersgroups.version>
+        <usersgroups.version>17.104.46</usersgroups.version>
```

## Why
Part of a 28-repo effort to bring `team/PEG-2848-R` into version-alignment with the passing `release-engg-2609` configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)