### PR TITLE
PEG-3470 Decouple staging-dcs from material-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <commons-dbutils.version>1.6</commons-dbutils.version>
         <jgitflow.maven.developBranchName>main</jgitflow.maven.developBranchName>
         <coredomain.version>17.103.13</coredomain.version>
-        <progression.version>17.0.269</progression.version>
-        <referencedata.version>17.103.133</referencedata.version>
+        <progression.version>17.0.286</progression.version>
+        <referencedata.version>17.104.140</referencedata.version>
         <defence.version>17.0.94</defence.version>
         <usersgroups.version>17.104.49</usersgroups.version>
         <material.version>17.0.80</material.version>

--- a/stagingdcs-event-processor/pom.xml
+++ b/stagingdcs-event-processor/pom.xml
@@ -68,11 +68,6 @@
             <artifactId>id-mapper-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>uk.gov.moj.cpp.material</groupId>
-            <artifactId>material-client</artifactId>
-            <version>${material.version}</version>
-        </dependency>
-        <dependency>
             <groupId>uk.gov.moj.cpp.core.domain</groupId>
             <artifactId>common-core-domain</artifactId>
             <version>${coredomain.version}</version>

--- a/stagingdcs-event-processor/src/main/java/uk/gov/moj/cpp/staging/dcs/event/service/MaterialService.java
+++ b/stagingdcs-event-processor/src/main/java/uk/gov/moj/cpp/staging/dcs/event/service/MaterialService.java
@@ -17,7 +17,7 @@ import uk.gov.justice.services.core.requester.Requester;
 import uk.gov.justice.services.messaging.Envelope;
 import uk.gov.justice.services.messaging.JsonEnvelope;
 import uk.gov.justice.services.messaging.Metadata;
-import uk.gov.moj.cpp.material.url.MaterialUrlGenerator;
+import uk.gov.moj.cpp.staging.dcs.material.client.MaterialUrlGenerator;
 import uk.gov.moj.cpp.systemusers.ServiceContextSystemUserProvider;
 
 import java.util.HashMap;

--- a/stagingdcs-event-processor/src/main/java/uk/gov/moj/cpp/staging/dcs/material/client/MaterialUrlGenerator.java
+++ b/stagingdcs-event-processor/src/main/java/uk/gov/moj/cpp/staging/dcs/material/client/MaterialUrlGenerator.java
@@ -1,0 +1,34 @@
+package uk.gov.moj.cpp.staging.dcs.material.client;
+
+import java.util.UUID;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * staging-dcs-owned copy of material's URL-building helper (decouples staging-dcs from the
+ * material-client JAR). Builds material download URL strings; no HTTP call is made here.
+ */
+@ApplicationScoped
+public class MaterialUrlGenerator {
+
+    private static final String BASE_URI = "http://localhost:8080/material-query-api/query/api/rest/material";
+    private static final String MATERIAL_REQUEST_PATH = "/material/";
+    private static final String MATERIAL_STREAM_PDF_PARAMETERS = "?stream=true&requestPdf=true";
+
+    private String baseFileStreamUrl(final UUID materialId) {
+        return BASE_URI + MATERIAL_REQUEST_PATH + materialId;
+    }
+
+    public String pdfFileStreamUrlFor(final UUID materialId) {
+        return baseFileStreamUrl(materialId) + MATERIAL_STREAM_PDF_PARAMETERS;
+    }
+
+    public String fileStreamUrlFor(final UUID materialId, final boolean pdfStream) {
+        return pdfStream ? pdfFileStreamUrlFor(materialId) : baseFileStreamUrl(materialId);
+    }
+
+    public String fileStreamUrlFor(final UUID materialId) {
+        return fileStreamUrlFor(materialId, false);
+    }
+
+}

--- a/stagingdcs-event-processor/src/test/java/uk/gov/moj/cpp/staging/dcs/event/service/MaterialServiceTest.java
+++ b/stagingdcs-event-processor/src/test/java/uk/gov/moj/cpp/staging/dcs/event/service/MaterialServiceTest.java
@@ -13,7 +13,7 @@ import static uk.gov.justice.services.common.http.HeaderConstants.USER_ID;
 
 import uk.gov.justice.services.core.requester.Requester;
 import uk.gov.justice.services.messaging.Envelope;
-import uk.gov.moj.cpp.material.url.MaterialUrlGenerator;
+import uk.gov.moj.cpp.staging.dcs.material.client.MaterialUrlGenerator;
 import uk.gov.moj.cpp.systemusers.ServiceContextSystemUserProvider;
 
 import java.util.List;


### PR DESCRIPTION
## Decouple staging-dcs from material-client (PEG-3470)

Breaks staging-dcs's compile-time dependency on `uk.gov.moj.cpp.material:material-client` so it can be built/released independently of material (Java-25 prerequisite cross-context decoupling).

- Copies material's `MaterialUrlGenerator` URL-builder into `uk.gov.moj.cpp.staging.dcs.material.client` (a single `@ApplicationScoped` class; constants inlined). No runtime change — staging-dcs still calls material over HTTP exactly as before.
- Removes the `material-client` dependency. Material JSON/RAML contract deps are unaffected.
- **Pre-existing stale interface pins bumped** to satisfy the MoJ-latest-interfaces enforcer: referencedata 17.103.133 → 17.104.140; progression 17.0.269 → 17.0.286.

Full reactor build green (JDK 17). Integration tests: **running** (will update).

Owning team: (to route). Refs: PEG-3470